### PR TITLE
Removal of gtk-info if not being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ about your system and prints it to the terminal next to an image of your choice!
 https://github.com/dylanaraps/fetch/wiki/Customizing-Info
 
 
-![1](http://i.imgur.com/bORHxT5.png)
+![1](http://i.imgur.com/oTxq5fA.png)
 
 
 <!-- Table of Contents {{{ -->


### PR DESCRIPTION
If GTK is not installed or being used, the information should not be printed, however if it is installed then of course it should be printed.

This pull will not print gtktheme or gtkicons if no gtk theme is installed