### PR TITLE
Rewrite GTK theme detection to also get correct DE theme.

### DIFF
--- a/fetch
+++ b/fetch
@@ -1144,7 +1144,7 @@ getgtk () {
 
         "Xfce"*)
             if type -p xfconf-query >/dev/null 2>&1; then
-                gtk2Theme=$(xfconf-query -c xsettings -p /Net/$xfconf)
+                gtk2theme=$(xfconf-query -c xsettings -p /Net/$xfconf)
             fi
         ;;
 

--- a/fetch
+++ b/fetch
@@ -1153,8 +1153,8 @@ getgtk () {
         ;;
     esac
 
-    if [ -z "$gtk2theme" ] && [ -z "$gtk3theme" ]; then
-        # Check for gtk2 theme
+    # Check for gtk2 theme
+    if [ -z "$gtk2theme" ]; then
         if [ -f "$HOME/.gtkrc-2.0" ]; then
             gtk2theme=$(grep "^[^#]*$name" "$HOME/.gtkrc-2.0")
 
@@ -1164,8 +1164,10 @@ getgtk () {
 
         gtk2theme=${gtk2theme/${name}*=}
         gtk2theme=${gtk2theme//\"}
+    fi
 
-        # Check for gtk3 theme
+    # Check for gtk3 theme
+    if [ -z "$gtk3theme" ]; then
         if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
             gtk3theme=$(grep "^[^#]*$name" "$HOME/.config/gtk-3.0/settings.ini")
 

--- a/fetch
+++ b/fetch
@@ -1178,6 +1178,10 @@ getgtk () {
         ;;
     esac
 
+    # Toggle visibility of gtk themes.
+    [ "$gtk2" == "off" ] && unset gtk2theme
+    [ "$gtk3" == "off" ] && unset gtk3theme
+
     # Format the string based on which themes exist
     if  [ "$gtk2theme" ] && [ "$gtk2theme" == "$gtk3theme" ]; then
         gtk3theme+=" [GTK2/3]"

--- a/fetch
+++ b/fetch
@@ -1086,56 +1086,97 @@ getresolution () {
 
 # }}}
 
-# GTK Theme/Icons/Font {{{
+# GTK Theme/Icons/Font New {{{
 
 getgtk () {
     case "$1" in
         theme)
             name="gtk-theme-name"
             gsettings="gtk-theme"
+            gconf="gtk_theme"
+            xfconf="ThemeName"
         ;;
 
         icons)
             name="gtk-icon-theme-name"
             gsettings="icon-theme"
+            gconf="icon_theme"
+            xfconf="IconThemeName"
         ;;
 
         font)
             name="gtk-font-name"
             gsettings="font-name"
+            gconf="font_theme"
+            xfconf="FontName"
         ;;
     esac
 
-    # Check for gtk2 theme
-    if [ "$gtk2" == "on" ]; then
-        if [ -f "$HOME/.gtkrc-2.0" ]; then
-            gtk2theme=$(grep "^[^#]*$name" "$HOME/.gtkrc-2.0")
+    # Current DE
+    desktop="$XDG_CURRENT_DESKTOP"
+    desktop=${desktop,,}
+    desktop=${desktop^}
 
-        elif [ -f "/etc/gtk-2.0/gtkrc" ]; then
-            gtk2theme=$(grep "^[^#]*$name" /etc/gtk-2.0/gtkrc)
-        fi
+    case "$desktop" in
+        "Cinnamon")
+            if type -p gsettings >/dev/null 2>&1; then
+                gtk3theme=$(gsettings get org.cinnamon.desktop.interface $gsettings)
+                gtk3theme=${gtk3theme//"'"}
+                gtk2theme=${gtk3theme}
+            fi
+        ;;
 
-        gtk2theme=${gtk2theme/${name}*=}
-        gtk2theme=${gtk2theme//\"}
-    fi
+        "Gnome"* | "Unity"* | "Budgie")
+            if type -p gsettings >/dev/null 2>&1; then
+                gtk3theme=$(gsettings get org.gnome.desktop.interface $gsettings)
+                gtk3theme=${gtk3theme//"'"}
+                gtk2theme=${gtk3theme}
 
-    # Check for gtk3 theme
-    if [ "$gtk3" == "on" ]; then
-        if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
-            gtk3theme=$(grep "^[^#]*$name" "$HOME/.config/gtk-3.0/settings.ini")
+            elif type -p gconftool-2 >/dev/null 2>&1; then
+                gtk2theme=$(gconftool-2 -g /desktop/gnome/interface/$gconf)
+            fi
+        ;;
 
-        elif type -p gsettings >/dev/null 2>&1; then
-            gtk3theme="$(gsettings get org.gnome.desktop.interface $gsettings)"
-            gtk3theme=${gtk3theme//\'}
+        "Mate"*)
+            gtk3theme=$(gsettings get org.mate.interface $gsettings)
+            gtk2theme=${gtk3theme}
+        ;;
 
-        else
-            gtk3theme=$(grep "^[^#]*$name" /etc/gtk-3.0/settings.ini)
-        fi
+        "Xfce"*)
+            if type -p xfconf-query >/dev/null 2>&1; then
+                gtk2Theme=$(xfconf-query -c xsettings -p /Net/$xfconf)
+            fi
+        ;;
 
-        gtk3theme=${gtk3theme/${name}*=}
-        gtk3theme=${gtk3theme//\"}
-        gtk3theme=${gtk3theme/[[:space:]]/ }
-    fi
+        *)
+            # Check for gtk2 theme
+            if [ -f "$HOME/.gtkrc-2.0" ]; then
+                gtk2theme=$(grep "^[^#]*$name" "$HOME/.gtkrc-2.0")
+
+            elif [ -f "/etc/gtk-2.0/gtkrc" ]; then
+                gtk2theme=$(grep "^[^#]*$name" /etc/gtk-2.0/gtkrc)
+            fi
+
+            gtk2theme=${gtk2theme/${name}*=}
+            gtk2theme=${gtk2theme//\"}
+
+            # Check for gtk3 theme
+            if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
+                gtk3theme=$(grep "^[^#]*$name" "$HOME/.config/gtk-3.0/settings.ini")
+
+            elif type -p gsettings >/dev/null 2>&1; then
+                gtk3theme="$(gsettings get org.gnome.desktop.interface $gsettings)"
+                gtk3theme=${gtk3theme//\'}
+
+            else
+                gtk3theme=$(grep "^[^#]*$name" /etc/gtk-3.0/settings.ini)
+            fi
+
+            gtk3theme=${gtk3theme/${name}*=}
+            gtk3theme=${gtk3theme//\"}
+            gtk3theme=${gtk3theme/[[:space:]]/ }
+        ;;
+    esac
 
     # Format the string based on which themes exist
     if  [ "$gtk2theme" ] && [ "$gtk2theme" == "$gtk3theme" ]; then

--- a/fetch
+++ b/fetch
@@ -1086,7 +1086,7 @@ getresolution () {
 
 # }}}
 
-# GTK Theme/Icons/Font New {{{
+# GTK Theme/Icons/Font {{{
 
 getgtk () {
     case "$1" in

--- a/fetch
+++ b/fetch
@@ -1089,6 +1089,10 @@ getresolution () {
 # GTK Theme/Icons/Font {{{
 
 getgtk () {
+    # Fix weird output when the function
+    # is run multiple times.
+    unset gtk2theme gtk3theme
+
     case "$1" in
         theme)
             name="gtk-theme-name"
@@ -1147,36 +1151,36 @@ getgtk () {
                 gtk2theme=$(xfconf-query -c xsettings -p /Net/$xfconf)
             fi
         ;;
-
-        *)
-            # Check for gtk2 theme
-            if [ -f "$HOME/.gtkrc-2.0" ]; then
-                gtk2theme=$(grep "^[^#]*$name" "$HOME/.gtkrc-2.0")
-
-            elif [ -f "/etc/gtk-2.0/gtkrc" ]; then
-                gtk2theme=$(grep "^[^#]*$name" /etc/gtk-2.0/gtkrc)
-            fi
-
-            gtk2theme=${gtk2theme/${name}*=}
-            gtk2theme=${gtk2theme//\"}
-
-            # Check for gtk3 theme
-            if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
-                gtk3theme=$(grep "^[^#]*$name" "$HOME/.config/gtk-3.0/settings.ini")
-
-            elif type -p gsettings >/dev/null 2>&1; then
-                gtk3theme="$(gsettings get org.gnome.desktop.interface $gsettings)"
-                gtk3theme=${gtk3theme//\'}
-
-            else
-                gtk3theme=$(grep "^[^#]*$name" /etc/gtk-3.0/settings.ini)
-            fi
-
-            gtk3theme=${gtk3theme/${name}*=}
-            gtk3theme=${gtk3theme//\"}
-            gtk3theme=${gtk3theme/[[:space:]]/ }
-        ;;
     esac
+
+    if [ -z "$gtk2theme" ] && [ -z "$gtk3theme" ]; then
+        # Check for gtk2 theme
+        if [ -f "$HOME/.gtkrc-2.0" ]; then
+            gtk2theme=$(grep "^[^#]*$name" "$HOME/.gtkrc-2.0")
+
+        elif [ -f "/etc/gtk-2.0/gtkrc" ]; then
+            gtk2theme=$(grep "^[^#]*$name" /etc/gtk-2.0/gtkrc)
+        fi
+
+        gtk2theme=${gtk2theme/${name}*=}
+        gtk2theme=${gtk2theme//\"}
+
+        # Check for gtk3 theme
+        if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
+            gtk3theme=$(grep "^[^#]*$name" "$HOME/.config/gtk-3.0/settings.ini")
+
+        elif type -p gsettings >/dev/null 2>&1; then
+            gtk3theme="$(gsettings get org.gnome.desktop.interface $gsettings)"
+            gtk3theme=${gtk3theme//\'}
+
+        else
+            gtk3theme=$(grep "^[^#]*$name" /etc/gtk-3.0/settings.ini)
+        fi
+
+        gtk3theme=${gtk3theme/${name}*=}
+        gtk3theme=${gtk3theme//\"}
+        gtk3theme=${gtk3theme/[[:space:]]/ }
+    fi
 
     # Toggle visibility of gtk themes.
     [ "$gtk2" == "off" ] && unset gtk2theme


### PR DESCRIPTION
This rewrite of the theme detection fixes cases where the gtk theme is 
incorrectly displayed due to the DE not writing `.gtkrc` files etc.

I've opened this PR to see if anyone has any ideas/queries about this before 
it gets pushed to master.

This is pretty much done, all that's missing is KDE support  and 
some error detection which I'm working on as we speak. 