### PR TITLE
IP Address support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ alias fetch2="fetch \
     --shell_version on/off      Enable/Disable showing \$SHELL version
     --battery_num num           Which battery to display, default value is 'all'
     --battery_shorthand on/off  Whether or not each battery gets its own line/title
+    --ip_host url               Url to ping for public IP
     --birthday_shorthand on/off Shorten the output of birthday
     --birthday_time on/off      Enable/Disable showing the time in birthday output
 
@@ -273,8 +274,6 @@ alias fetch2="fetch \
     --shuffle_dir path/to/dir   Which directory to shuffle for an image.
     --font_width px             Used to automatically size the image
     --image_position left/right Where to display the image: (Left/Right)
-    --split_size num            Width of img/text splits, A value of 2 makes each
-                                split half the terminal width and etc.
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill
     --crop_offset value         Change the crop offset for normal mode.

--- a/config/config
+++ b/config/config
@@ -130,6 +130,13 @@ battery_num="all"
 battery_shorthand="off"
 
 
+# IP Address
+
+# Website to ping for the public IP
+# --ip_host url
+public_ip_host="http://ident.me"
+
+
 # Birthday
 
 # Whether to show a long pretty output

--- a/fetch
+++ b/fetch
@@ -150,6 +150,13 @@ battery_num="all"
 battery_shorthand="off"
 
 
+# IP Address
+
+# Website to ping for the public IP
+# --ip_host url
+public_ip_host="http://ident.me"
+
+
 # Birthday
 
 # Whether to show a long pretty output
@@ -1360,10 +1367,10 @@ getlocalip () {
 
 getpublicip () {
     if type -p curl >/dev/null 2>&1; then
-        publicip="$(curl -w '\n' http://ident.me)"
+        publicip="$(curl -w '\n' "$public_ip_host")"
 
     elif type -p wget >/dev/null 2>&1; then
-        publicip="$(wget -qO- http://ident.me; printf "%s")"
+        publicip="$(wget -qO- "$public_ip_host"; printf "%s")"
 
     else
         publicip="Unknown"
@@ -2151,6 +2158,7 @@ usage () { cat << EOF
     --shell_version on/off      Enable/Disable showing \$SHELL version
     --battery_num num           Which battery to display, default value is 'all'
     --battery_shorthand on/off  Whether or not each battery gets its own line/title
+    --ip_host url               Url to ping for public IP
     --birthday_shorthand on/off Shorten the output of birthday
     --birthday_time on/off      Enable/Disable showing the time in birthday output
 
@@ -2255,6 +2263,7 @@ while [ "$1" ]; do
         --shell_version) shell_version="$2" ;;
         --battery_num) battery_num="$2" ;;
         --battery_shorthand) battery_shorthand="$2" ;;
+        --ip_host) public_ip_host="$2" ;;
         --birthday_shorthand) birthday_shorthand="$2" ;;
         --birthday_time) birthday_time="$2" ;;
         --disable)

--- a/fetch
+++ b/fetch
@@ -1355,6 +1355,11 @@ getlocalip () {
             [ -z "$localip" ] && localip="$(ipconfig getifaddr en1)"
         ;;
 
+        *"BSD")
+            localip="$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' \
+                | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')"
+        ;;
+
         "Windows")
             localip="$(ipconfig | awk -F ': ' '/IPv4 Address/ {printf $2}')"
         ;;

--- a/fetch
+++ b/fetch
@@ -1358,6 +1358,18 @@ getlocalip () {
     esac
 }
 
+getpublicip () {
+    if type -p curl >/dev/null 2>&1; then
+        publicip="$(curl -w '\n' http://ident.me)"
+
+    elif type -p wget >/dev/null 2>&1; then
+        publicip="$(wget -qO- http://ident.me; printf "%s")"
+
+    else
+        publicip="Unknown"
+    fi
+}
+
 # }}}
 
 # Birthday {{{

--- a/fetch
+++ b/fetch
@@ -1356,8 +1356,7 @@ getlocalip () {
         ;;
 
         *"BSD")
-            localip="$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' \
-                | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')"
+            localip="$(ifconfig | awk '/broadcast/ {print $2}')"
         ;;
 
         "Windows")

--- a/fetch
+++ b/fetch
@@ -1343,6 +1343,11 @@ getlocalip () {
             localip="$(ip route get 1 | awk '{print $NF;exit}')"
         ;;
 
+        "Mac OS X")
+            localip="$(ipconfig getifaddr en0)"
+            [ -z "$localip" ] && localip="$(ipconfig getifaddr en1)"
+        ;;
+
         "Windows")
             localip="$(ipconfig | awk -F ': ' '/IPv4 Address/ {printf $2}')"
         ;;

--- a/fetch
+++ b/fetch
@@ -1335,6 +1335,26 @@ getbattery () {
 
 # }}}
 
+# IP Address {{{
+
+getlocalip () {
+    case "$os" in
+        "Linux")
+            localip="$(ip route get 1 | awk '{print $NF;exit}')"
+        ;;
+
+        "Windows")
+            localip="$(ipconfig | awk -F ': ' '/IPv4 Address/ {printf $2}')"
+        ;;
+
+        *)
+            localip="Unknown"
+        ;;
+    esac
+}
+
+# }}}
+
 # Birthday {{{
 
 getbirthday () {


### PR DESCRIPTION
IP support is done in my eyes.

I've tested this PR with these OS and it works fine without issues.

- 8 linux distros
- 3 BSD distros
- Windows 7 

Before I push this to master I'd you guys to test this out!

You can test it by swapping to the `ip` branch and adding these 
lines to your printinfo function:

```sh
info "Local IP" localip
info "Public IP" publicip
```

If you guys have any suggestions for features/changes now is 
the time to speak up.
