### PR TITLE
Fixed uptime output when the uptime is under a minute

### DIFF
--- a/fetch
+++ b/fetch
@@ -527,7 +527,7 @@ getuptime () {
 
                 *)
                     uptime="$(uptime -p)"
-                    [ "$uptime" == "up " ] && uptime="up $(cat /proc/uptime)"
+                    [ "$uptime" == "up " ] && uptime="up $(cat /proc/uptime | cut -d'.' -f1) seconds"
                 ;;
             esac
         ;;

--- a/fetch
+++ b/fetch
@@ -527,6 +527,7 @@ getuptime () {
 
                 *)
                     uptime="$(uptime -p)"
+                    [ "$uptime" == "up" ] && uptime="up $(cat /proc/uptime)"
                 ;;
             esac
         ;;

--- a/fetch
+++ b/fetch
@@ -527,7 +527,7 @@ getuptime () {
 
                 *)
                     uptime="$(uptime -p)"
-                    [ "$uptime" == "up " ] && uptime="up $(cat /proc/uptime | cut -d'.' -f1) seconds"
+                    [ "$uptime" == "up " ] && uptime="up $(awk -F'.' '{print $1}') seconds"
                 ;;
             esac
         ;;
@@ -583,6 +583,7 @@ getuptime () {
             uptime=${uptime/up}
             uptime=${uptime/minutes/mins}
             uptime=${uptime/minute/min}
+            uptime=${uptime/seconds/secs}
             uptime=${uptime# }
         ;;
 
@@ -594,6 +595,7 @@ getuptime () {
             uptime=${uptime/ hour/h}
             uptime=${uptime/ minutes/m}
             uptime=${uptime/ minute/m}
+            uptime=${uptime/ seconds/s}
             uptime=${uptime/,}
             uptime=${uptime# }
         ;;

--- a/fetch
+++ b/fetch
@@ -527,7 +527,7 @@ getuptime () {
 
                 *)
                     uptime="$(uptime -p)"
-                    [ "$uptime" == "up" ] && uptime="up $(cat /proc/uptime)"
+                    [ "$uptime" == "up " ] && uptime="up $(cat /proc/uptime)"
                 ;;
             esac
         ;;

--- a/fetch
+++ b/fetch
@@ -527,7 +527,7 @@ getuptime () {
 
                 *)
                     uptime="$(uptime -p)"
-                    [ "$uptime" == "up " ] && uptime="up $(awk -F'.' '{print $1}') seconds"
+                    [ "$uptime" == "up " ] && uptime="up $(awk -F'.' '{print $1}' /proc/uptime) seconds"
                 ;;
             esac
         ;;


### PR DESCRIPTION
Before this fix, if the uptime was under a minute, it showed as `Uptime: up`. You don't say?