### PR TITLE
Check for packages based on which package manager is installed.

### DIFF
--- a/fetch
+++ b/fetch
@@ -638,6 +638,9 @@ getpackages () {
 
             elif type -p nix-env >/dev/null 2>&1; then
                 packages="$(ls -d -1 /nix/store/*/ | wc -l)"
+
+            elif type -p pacman-g2 >/dev/null 2>&1; then
+                packages="$(pacman-g2 -Q | wc -l)"
             fi
         ;;
 

--- a/fetch
+++ b/fetch
@@ -607,50 +607,41 @@ getuptime () {
 # Package Count {{{
 
 getpackages () {
-    case "$distro" in
-        "Arch Linux"* | "Parabola"* | "Manjaro"* | "Antergos"* | "Chakra"*)
-            packages="$(pacman -Qq --color never | wc -l)"
+    case "$os" in
+        "Linux")
+            if type -p dpkg >/dev/null 2>&1; then
+                packages="$(dpkg --get-selections | grep -cv deinstall$)"
+
+            elif type -p pacman >/dev/null 2>&1; then
+                packages="$(pacman -Qq --color never | wc -l)"
+
+            elif type -p rpm >/dev/null 2>&1; then
+                packages="$(rpm -qa | wc -l)"
+
+            elif type -p xbps-query >/dev/null 2>&1; then
+                packages="$(xbps-query -l | wc -l)"
+
+            elif type -p pkginfo >/dev/null 2>&1; then
+                packages="$(pkginfo -i | wc -l)"
+
+            elif type -p pisi >/dev/null 2>&1; then
+                packages="$(pisi list-installed | wc -l)"
+
+            elif type -p pkg >/dev/null 2>&1; then
+                packages="$(ls -1 /var/db/pkg | wc -l)"
+
+            elif type -p pkgtool >/dev/null 2>&1; then
+                packages="$(ls -1 /var/log/packages | wc -l)"
+
+            elif type -p emerge >/dev/null 2>&1; then
+                packages="$(ls -d /var/db/pkg/*/* | wc -l)"
+
+            elif type -p nix-env >/dev/null 2>&1; then
+                packages="$(ls -d -1 /nix/store/*/ | wc -l)"
+            fi
         ;;
 
-        "Dragora"*)
-            packages="$(ls -1 /var/db/pkg | wc -l)"
-        ;;
-
-        "void"*)
-            packages="$(xbps-query -l | wc -l)"
-        ;;
-
-        "Ubuntu"* | *"Mint"* | "CrunchBang"* | "Debian"* | "Kali"* | "Deepin Linux"* |\
-        "elementary"* | "Raspbian"* | "Zorin"* | "Tails"* | "Trisquel"*)
-            packages="$(dpkg --get-selections | grep -cv deinstall$)"
-        ;;
-
-        "Slackware"*)
-            packages="$(ls -1 /var/log/packages | wc -l)"
-        ;;
-
-        "Gentoo"* | "Funtoo"*)
-            packages="$(ls -d /var/db/pkg/*/* | wc -l)"
-        ;;
-
-        "NixOS"*)
-            packages="$(ls -d -1 /nix/store/*/ | wc -l)"
-        ;;
-
-        "Fedora"* | "openSUSE"* | "Red Hat"* | "CentOS"* | "Mageia"* | "PCLinuxOS"* |\
-        "BLAG"*)
-            packages="$(rpm -qa | wc -l)"
-        ;;
-
-        "CRUX"*)
-            packages="$(pkginfo -i | wc -l)"
-        ;;
-
-        "Solus"*)
-            packages="$(pisi list-installed | wc -l)"
-        ;;
-
-        "Mac OS X"*)
+        "Mac OS X")
             if [ -d "/usr/local/bin" ]; then
                 local_packages=$(ls -l /usr/local/bin/ | grep -v "\(../Cellar/\|brew\)" | wc -l)
                 packages=$((local_packages - 1))
@@ -672,15 +663,16 @@ getpackages () {
             fi
         ;;
 
-        "OpenBSD"* | "NetBSD"*)
-            packages=$(pkg_info | wc -l)
+        *"BSD")
+            if type -p pkg_info >/dev/null 2>&1; then
+                packages=$(pkg_info | wc -l)
+
+            elif type -p pkg >/dev/null 2>&1; then
+                packages=$(pkg info | wc -l)
+            fi
         ;;
 
-        "FreeBSD"*)
-            packages=$(pkg info | wc -l)
-        ;;
-
-        "Windows"*)
+        "Windows")
             packages=$(cygcheck -cd | wc -l)
 
             # Count chocolatey packages
@@ -689,13 +681,10 @@ getpackages () {
                 packages=$((packages + choco_packages))
             fi
         ;;
-
-        *)
-            packages="Unknown"
-        ;;
     esac
-
     packages=${packages// }
+
+    [ -z "$packages" ] && packages="Unknown"
 }
 
 # }}}


### PR DESCRIPTION
This PR changes the way we get package count by checking which
package manager is installed instead of hardcoding a list of distros.

This means that all we will need to do to add a new linux distro is
add the ascii art/colors.

**Cons**: 
- Slightly slower on Linux if the package manager is towards the bottom
of the if block. (All other OS had a speedup.)

Thanks @tudurom for the idea! :)