### PR TITLE
getgtk changes

### DIFF
--- a/config/config
+++ b/config/config
@@ -28,8 +28,8 @@ printinfo () {
     info "Shell" shell
     info "Desktop Environment" de
     info "Window Manager" wm
-    info "GTK Theme" gtktheme
-    info "Icons" gtkicons
+    info "Theme" theme
+    info "Icons" icons
     info "CPU" cpu
     info "GPU" gpu
     info "Memory" memory

--- a/fetch
+++ b/fetch
@@ -1196,7 +1196,7 @@ getstyle () {
                 kde_config_file="${kde_config_dir}/share/config/kdeglobals"
 
                 theme=$(grep "^[^#]*$kde" "$kde_config_file")
-                theme=${gtk3theme/${kde}*=}
+                theme=${theme/${kde}*=}
 
                 gtk_shorthand="on"
                 return

--- a/fetch
+++ b/fetch
@@ -1155,6 +1155,7 @@ getgtk () {
             gsettings="gtk-theme"
             gconf="gtk_theme"
             xfconf="ThemeName"
+            kde="widgetStyle"
         ;;
 
         icons)
@@ -1162,6 +1163,7 @@ getgtk () {
             gsettings="icon-theme"
             gconf="icon_theme"
             xfconf="IconThemeName"
+            kde="Theme"
         ;;
 
         font)
@@ -1169,6 +1171,7 @@ getgtk () {
             gsettings="font-name"
             gconf="font_theme"
             xfconf="FontName"
+            kde="font"
         ;;
     esac
 
@@ -1178,6 +1181,19 @@ getgtk () {
     desktop=${desktop^}
 
     case "$desktop" in
+        "KDE"*)
+            if type -p kde5-config >/dev/null 2>&1; then
+                kde_config_dir=$(kde5-config --localprefix)
+
+                if [ -f "${kde_config_dir}/share/config/kdeglobals" ]; then
+                    kde_config_file="${kde_config_dir}/share/config/kdeglobals"
+
+                    gtk3theme=$(grep "^[^#]*$kde" "$kde_config_file")
+                    gtk3theme=${gtk3theme/${kde}*=}
+                fi
+            fi
+        ;;
+
         "Cinnamon")
             if type -p gsettings >/dev/null 2>&1; then
                 gtk3theme=$(gsettings get org.cinnamon.desktop.interface $gsettings)

--- a/fetch
+++ b/fetch
@@ -1197,6 +1197,7 @@ getstyle () {
 
                 theme=$(grep "^[^#]*$kde" "$kde_config_file")
                 theme=${theme/${kde}*=}
+                theme=${theme^}
 
                 gtk_shorthand="on"
                 return

--- a/fetch
+++ b/fetch
@@ -47,8 +47,8 @@ printinfo () {
     info "Shell" shell
     info "Desktop Environment" de
     info "Window Manager" wm
-    info "GTK Theme" gtktheme
-    info "Icons" gtkicons
+    info "Theme" theme
+    info "Icons" icons
     info "CPU" cpu
     info "GPU" gpu
     info "Memory" memory
@@ -1142,9 +1142,9 @@ getresolution () {
 
 # }}}
 
-# GTK Theme/Icons/Font {{{
+# Theme/Icons/Font {{{
 
-getgtk () {
+getstyle () {
     # Fix weird output when the function
     # is run multiple times.
     unset gtk2theme gtk3theme
@@ -1195,8 +1195,10 @@ getgtk () {
             if [ -f "${kde_config_dir}/share/config/kdeglobals" ]; then
                 kde_config_file="${kde_config_dir}/share/config/kdeglobals"
 
-                gtktheme=$(grep "^[^#]*$kde" "$kde_config_file")
-                gtktheme=${gtk3theme/${kde}*=}
+                theme=$(grep "^[^#]*$kde" "$kde_config_file")
+                theme=${gtk3theme/${kde}*=}
+
+                gtk_shorthand="on"
                 return
             fi
         ;;
@@ -1281,31 +1283,31 @@ getgtk () {
     fi
 
     # Final string
-    gtktheme="${gtk2theme}${gtk3theme}"
+    theme="${gtk2theme}${gtk3theme}"
 
     # If the final string is empty print "None"
-    [ -z "$gtktheme" ] && gtktheme="None"
+    [ -z "$theme" ] && theme="None"
 
     # Make the output shorter by removing "[GTKX]" from the string
     if [ "$gtk_shorthand" == "on" ]; then
-        gtktheme=${gtktheme/ '[GTK2]'}
-        gtktheme=${gtktheme/ '[GTK3]'}
-        gtktheme=${gtktheme/ '[GTK2/3]'}
+        theme=${theme/ '[GTK2]'}
+        theme=${theme/ '[GTK3]'}
+        theme=${theme/ '[GTK2/3]'}
     fi
 }
 
-getgtktheme () {
-    getgtk theme
+gettheme () {
+    getstyle theme
 }
 
-getgtkicons () {
-    getgtk icons
-    gtkicons="$gtktheme"
+geticons () {
+    getstyle icons
+    icons="$theme"
 }
 
-getgtkfont () {
-    getgtk font
-    gtkfont="$gtktheme"
+getfont () {
+    getstyle font
+    font="$theme"
 }
 
 # }}}

--- a/fetch
+++ b/fetch
@@ -1195,8 +1195,9 @@ getgtk () {
             if [ -f "${kde_config_dir}/share/config/kdeglobals" ]; then
                 kde_config_file="${kde_config_dir}/share/config/kdeglobals"
 
-                gtk3theme=$(grep "^[^#]*$kde" "$kde_config_file")
-                gtk3theme=${gtk3theme/${kde}*=}
+                gtktheme=$(grep "^[^#]*$kde" "$kde_config_file")
+                gtktheme=${gtk3theme/${kde}*=}
+                return
             fi
         ;;
 

--- a/fetch
+++ b/fetch
@@ -1185,12 +1185,18 @@ getgtk () {
             if type -p kde5-config >/dev/null 2>&1; then
                 kde_config_dir=$(kde5-config --localprefix)
 
-                if [ -f "${kde_config_dir}/share/config/kdeglobals" ]; then
-                    kde_config_file="${kde_config_dir}/share/config/kdeglobals"
+            elif type -p kde4-config >/dev/null 2>&1; then
+                kde_config_dir=$(kde4-config --localprefix)
 
-                    gtk3theme=$(grep "^[^#]*$kde" "$kde_config_file")
-                    gtk3theme=${gtk3theme/${kde}*=}
-                fi
+            elif type -p kde-config >/dev/null 2>&1; then
+                kde_config_dir=$(kde-config --localprefix)
+            fi
+
+            if [ -f "${kde_config_dir}/share/config/kdeglobals" ]; then
+                kde_config_file="${kde_config_dir}/share/config/kdeglobals"
+
+                gtk3theme=$(grep "^[^#]*$kde" "$kde_config_file")
+                gtk3theme=${gtk3theme/${kde}*=}
             fi
         ;;
 


### PR DESCRIPTION
`getgtk` is now a generic theme function and now supports KDE.

- Added support for getting KDE theme.
- Renamed `getgtk` to `getstyle`.
- Renamed `getgtktheme` to `gettheme`.
- Renamed `getgtkicons` to `geticons`.
- Renamed `getgtkfont` to `getfont`.
- Changed `GTK Theme` title in printinfo to `Theme`.

These changes were made because the function now also supports
KDE which is based on QT and the naming/titles are misleading.

You'll need to update your config file due to the new function names. 

```sh
# Old naming
info "GTK Theme" gtktheme
info "Icons" gtkicons
info "Font" gtkfont

# New naming
info "Theme" theme
info "Icons" icons
info "Font" font
```

Let me know what you guys think.