### PR TITLE
Use 'xprop' instead of 'wmctrl' to get the window manager.

### DIFF
--- a/1.2.md
+++ b/1.2.md
@@ -63,7 +63,7 @@ fixes issues where the wallpaper set by gsettings is an xml file.
 - Added support for showing the user's DE.
 
 **Window Manager**:
-- `wmctrl` is now a required dependency. See **[#75](https://github.com/dylanaraps/fetch/issues/75)**.
+- `xprop` is now a required dependency. See **[#75](https://github.com/dylanaraps/fetch/issues/75)**.
 - Renamed 'windowmanager' to 'wm'
 
 **IP Address**:

--- a/1.2.md
+++ b/1.2.md
@@ -63,7 +63,7 @@ fixes issues where the wallpaper set by gsettings is an xml file.
 - Added support for showing the user's DE.
 
 **Window Manager**:
-- `xprop` is now a required dependency. See **[#75](https://github.com/dylanaraps/fetch/issues/75)**.
+- `xprop` is now a required dependency. See **[#79](https://github.com/dylanaraps/fetch/issues/79)**
 - Renamed 'windowmanager' to 'wm'
 
 **IP Address**:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ your distro's logo or any ascii art of your choice!
 \[2\] You can enable the `iTerm2` image backend by using the launch flag `--image_backend iterm2` or by<br \>
 changing the config option `$image_backend` to `iterm2`.
 
-\[3\] See **#75** about why this is now a required dependency.
+\[3\] See **[#79](https://github.com/dylanaraps/fetch/issues/79)** about why this is now a required dependency.
 
 \[4\] You can use the launch flag `--scrot_cmd` or change the config option `$scrot_cmd` to your screenshot<br \>
 program's cmd and fetch will use it instead of scrot.

--- a/README.md
+++ b/README.md
@@ -68,12 +68,9 @@ your distro's logo or any ascii art of your choice!
 ### Required dependencies:
 
 - `Bash 4.0+`
+- `xprop` \[3\]
 - `procps-ng`
     - Not required on OS X
-
-##### Linux / BSD
-
-- `wmctrl` \[3\]
 
 
 ### Optional dependencies:

--- a/fetch
+++ b/fetch
@@ -6,13 +6,12 @@
 #
 # Required Dependencies:
 #   Bash 4.0+
-#   Text formatting, dynamic image size and padding: tput
+#   xprop
 #   [Linux / BSD / Windows] Uptime detection: procps or procps-ng
 #
 # Optional Dependencies: (You'll lose these features without them)
 #   Displaying Images: w3m + w3m-img
 #   Image Cropping: ImageMagick
-#   More accurate window manager detection: wmctrl
 #   [ Linux / BSD ] Wallpaper Display: feh, nitrogen or gsettings
 #   [ Linux / BSD ] Current Song: mpc or cmus
 #   [ Linux / BSD ] Resolution detection: xorg-xdpyinfo

--- a/fetch
+++ b/fetch
@@ -749,6 +749,14 @@ getwm () {
     if type -p wmctrl >/dev/null 2>&1; then
         wm="$(wmctrl -m | head -n1)"
         wm=${wm/Name: }
+
+    elif [ -n "$DISPLAY" ]; then
+        id="$(xprop -root -notype | \awk '$1=="_NET_SUPPORTING_WM_CHECK:"{print $5}')"
+        wm="$(xprop -id "$id" -notype -f _NET_WM_NAME 8t)"
+        wm=${wm/*_NET_WM_NAME = }
+        wm=${wm/\"}
+        wm=${wm/\"*}
+
     else
         case "$os" in
             "Mac OS X") wm="Quartz Compositor" ;;

--- a/fetch
+++ b/fetch
@@ -746,11 +746,7 @@ getde () {
 # Window Manager {{{
 
 getwm () {
-    if type -p wmctrl >/dev/null 2>&1; then
-        wm="$(wmctrl -m | head -n1)"
-        wm=${wm/Name: }
-
-    elif [ -n "$DISPLAY" ]; then
+    if [ -n "$DISPLAY" ]; then
         id="$(xprop -root -notype | \awk '$1=="_NET_SUPPORTING_WM_CHECK:"{print $5}')"
         wm="$(xprop -id "$id" -notype -f _NET_WM_NAME 8t)"
         wm=${wm/*_NET_WM_NAME = }


### PR DESCRIPTION
I did an strace of `wmctrl -m` and it turns out that it gets the window 
manager name from `_NET_WM_NAME`.  I did some googling and we 
can use xprop to get the value of `_NET_WM_NAME` which means
that we can swap the dependency from wmctrl to xprop.

xprop is available almost everywhere which means that users running
X under Mac OS X and Windows will now get the window manager info
too!

I'm currently going through VMs testing this change but it seems like
it should work anyway. 