### PR TITLE
Font size is now calculated by fetch

### DIFF
--- a/1.3.md
+++ b/1.3.md
@@ -1,5 +1,1 @@
 # Fetch 1.3
-
-- You no longer need to set the font_width value, your font size<br \>
-is now calculated by fetch.
-- Image sizing now takes terminal height into account.

--- a/1.3.md
+++ b/1.3.md
@@ -1,1 +1,5 @@
 # Fetch 1.3
+
+- You no longer need to set the font_width value, your font size<br \>
+is now calculated by fetch.
+- Image sizing now takes terminal height into account.

--- a/README.md
+++ b/README.md
@@ -63,18 +63,17 @@ your distro's logo or any ascii art of your choice!
 
 ## Dependencies
 
-
 ### Required dependencies:
 
 - `Bash 4.0+`
-- `xprop` \[3\]
+- `xprop` \[1\]
 - `procps-ng`
     - Not required on OS X
 
 
 ### Optional dependencies:
 
-- Displaying images: `w3m-img` \[1\] or `iTerm2` \[2\]
+- Displaying images: `w3m-img` \[2\] \[3\] or `iTerm2` \[4\]
 - Thumbnail creation: `imagemagick`
 
 ##### Linux / BSD
@@ -82,16 +81,20 @@ your distro's logo or any ascii art of your choice!
 - Wallpaper: `feh`, `nitrogen` or `gsettings`
 - Current Song: `mpc` or `cmus`
 - Resolution: `xorg-xdpyinfo`
-- Screenshot: `scrot` \[4\]
+- Screenshot: `scrot` \[5\]
 
-\[1\] `w3m-img` is sometimes bundled together with `w3m`.
 
-\[2\] You can enable the `iTerm2` image backend by using the launch flag `--image_backend iterm2` or by<br \>
+\[1\] See **[#79](https://github.com/dylanaraps/fetch/issues/79)** about why this is now a required dependency.
+
+\[2\] `w3m-img` is sometimes bundled together with `w3m`.
+
+\[3\] Image support only works in certain terminal emulators. The script will fallback to ascii mode on<br \>
+terminal emulators that don't support the xterm escape sequences we're using for image sizing.
+
+\[4\] You can enable the `iTerm2` image backend by using the launch flag `--image_backend iterm2` or by<br \>
 changing the config option `$image_backend` to `iterm2`.
 
-\[3\] See **[#79](https://github.com/dylanaraps/fetch/issues/79)** about why this is now a required dependency.
-
-\[4\] You can use the launch flag `--scrot_cmd` or change the config option `$scrot_cmd` to your screenshot<br \>
+\[5\] You can use the launch flag `--scrot_cmd` or change the config option `$scrot_cmd` to your screenshot<br \>
 program's cmd and fetch will use it instead of scrot.
 
 

--- a/README.md
+++ b/README.md
@@ -170,19 +170,6 @@ You can launch the script without a config file by using the flag `--config none
 specify a custom config location using `--config path/to/config`.
 
 
-#### Sizing the image correctly
-
-**NOTE:** For the images to be sized correctly you need to set the `$font_width` variable.<br \>
-If you don't know your font width in pixels keep trying values until the image is half the<br \>
-terminal width.
-
-Once `font_width` is set the image will by default take up half the terminal width. You can<br \>
-use the launch flag `--size px` or change the config option `$image_size` to set it to a custom<br \>
-size in pixels.
-
-You can also use the launch flag `--font_width` to set it on the fly.
-
-
 #### Setting the prompt height
 
 If your shell prompt's height is greater than 1 line high, you'll need to change a config<br \>
@@ -289,7 +276,6 @@ alias fetch2="fetch \
     --size px                   Size in pixels to make the image.
     --image_backend w3m/iterm2  Which program to use to draw images.
     --shuffle_dir path/to/dir   Which directory to shuffle for an image.
-    --font_width px             Used to automatically size the image
     --image_position left/right Where to display the image: (Left/Right)
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill

--- a/config/config
+++ b/config/config
@@ -260,11 +260,6 @@ crop_mode="normal"
 #               east/southwest/south/southeast
 crop_offset="center"
 
-# Font width
-# --font_width num
-# Used when calculating dynamic image size
-font_width=5
-
 # Image size
 # The image is half the terminal width by default.
 # --size half, px

--- a/config/config
+++ b/config/config
@@ -262,8 +262,8 @@ crop_offset="center"
 
 # Image size
 # The image is half the terminal width by default.
-# --size half, px
-image_size="half"
+# --size auto, px
+image_size="auto"
 
 # Right gap between image and text
 # --gap num

--- a/fetch
+++ b/fetch
@@ -278,11 +278,6 @@ crop_mode="normal"
 #               east/southwest/south/southeast
 crop_offset="center"
 
-# Font width
-# Used when calculating dynamic image size
-# --font_width num
-font_width=5
-
 # Image size
 # The image is half the terminal width by default.
 # --size half, px
@@ -1865,13 +1860,33 @@ getimage () {
         return
     fi
 
-    # Get lines and columns
+    # Get terminal lines and columns
     columns=$(tput cols)
     lines=$(tput lines)
 
+    # Get terminal width and height
+    printf "%b%s" '\033[14t'
+
+    index=0
+    while IFS= read -s -r -n 1 char; do
+        case "$index" in
+            "0") [ "$char" == ";" ] && index=$((index + 1)) ;;
+            "1") [ "$char" == ";" ] && index=$((index + 1)) || term_height="${term_height}${char}" ;;
+            "2") [ "$char" == "t" ] && break || term_width="${term_width}${char}"
+        esac
+    done
+
+    # Calculate font size
+    font_width=$((term_width / columns))
+    font_height=$((term_height / lines))
+
     # Image size is half of the terminal
-    [ "$image_size" == "half" ] && \
+    if [ "$image_size" == "half" ]; then
         image_size=$((columns * font_width / 2))
+
+        [ "$((term_height - term_height / 4))" -lt "$image_size" ] && \
+            image_size=$((term_height - term_height / 4))
+    fi
 
     # Where to draw the image
     case "$image_position" in
@@ -2307,7 +2322,6 @@ usage () { cat << EOF
     --size px                   Size in pixels to make the image.
     --image_backend w3m/iterm2  Which program to use to draw images.
     --shuffle_dir path/to/dir   Which directory to shuffle for an image.
-    --font_width px             Used to automatically size the image
     --image_position left/right Where to display the image: (Left/Right)
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill
@@ -2421,7 +2435,6 @@ while [ "$1" ]; do
         --size) image_size="$2" ;;
         --image_backend) image_backend="$2" ;;
         --shuffle_dir) shuffle_dir="$2" ;;
-        --font_width) font_width="$2" ;;
         --image_position) image_position="$2" ;;
         --crop_mode) crop_mode="$2" ;;
         --crop_offset) crop_offset="$2" ;;

--- a/fetch
+++ b/fetch
@@ -280,8 +280,8 @@ crop_offset="center"
 
 # Image size
 # The image is half the terminal width by default.
-# --size half, px
-image_size="half"
+# --size auto, px
+image_size="auto"
 
 # Right gap between image and text
 # --gap num
@@ -1851,8 +1851,21 @@ getimage () {
         ;;
     esac
 
-    # If $img isn't a file, fallback to ascii mode.
-    if [ ! -f "$img" ]; then
+    # Get terminal width and height
+    printf "%b%s" '\033[14t'
+
+    index=0
+    while IFS= read -s -r -n 1 -t 0.25 char; do
+        case "$index" in
+            "0") [ "$char" == ";" ] && index=$((index + 1)) ;;
+            "1") [ "$char" == ";" ] && index=$((index + 1)) || term_height="${term_height}${char}" ;;
+            "2") [ "$char" == "t" ] && break || term_width="${term_width}${char}"
+        esac
+    done
+
+    # If $img isn't a file or the terminal doesn't support xterm escape sequences,
+    # fallback to ascii mode.
+    if [ ! -f "$img" ] || [ -z "$term_height" ]; then
         # Fallback to ascii mode
         image="ascii"
         getascii
@@ -1864,24 +1877,12 @@ getimage () {
     columns=$(tput cols)
     lines=$(tput lines)
 
-    # Get terminal width and height
-    printf "%b%s" '\033[14t'
-
-    index=0
-    while IFS= read -s -r -n 1 char; do
-        case "$index" in
-            "0") [ "$char" == ";" ] && index=$((index + 1)) ;;
-            "1") [ "$char" == ";" ] && index=$((index + 1)) || term_height="${term_height}${char}" ;;
-            "2") [ "$char" == "t" ] && break || term_width="${term_width}${char}"
-        esac
-    done
-
     # Calculate font size
     font_width=$((term_width / columns))
     font_height=$((term_height / lines))
 
     # Image size is half of the terminal
-    if [ "$image_size" == "half" ]; then
+    if [ "$image_size" == "auto" ]; then
         image_size=$((columns * font_width / 2))
 
         [ "$((term_height - term_height / 4))" -lt "$image_size" ] && \


### PR DESCRIPTION
The user no longer has to set the `font_width` value, fetch calculates it using
terminal size and number of columns/lines.

This change also makes image sizing take terminal height into account, this
fixes issues with terminals where the height is far lower than the width. 

This seems to work in all terminal emulators and font sizes I've tried but I'd
still like some people to test it out!

Thanks