### PR TITLE
Merge `getvisualstyle` with `getstyle`.

### DIFF
--- a/fetch
+++ b/fetch
@@ -1178,7 +1178,7 @@ getresolution () {
 getstyle () {
     # Fix weird output when the function
     # is run multiple times.
-    unset gtk2theme gtk3theme
+    unset gtk2theme gtk3theme theme path
 
     case "$1" in
         theme)
@@ -1334,6 +1334,7 @@ getstyle () {
     else
         case "$os" in
             "Windows")
+                [ ! "$path" ] && return
                 theme="$(head -n1 $path 2>/dev/null)"
                 theme="${theme##*\\}"
                 theme="${theme%.*}"

--- a/fetch
+++ b/fetch
@@ -1331,7 +1331,7 @@ getstyle () {
     else
         case "$os" in
             "Windows")
-                [ ! "$path" ] && return
+                [ -z "$path" ] && return
                 theme="$(head -n1 $path 2>/dev/null)"
                 theme="${theme##*\\}"
                 theme="${theme%.*}"

--- a/fetch
+++ b/fetch
@@ -1176,9 +1176,6 @@ getresolution () {
 # Theme/Icons/Font {{{
 
 getstyle () {
-    # If X isn't running don't print the theme.
-    [ ! -n "$DISPLAY" ] && return
-
     # Fix weird output when the function
     # is run multiple times.
     unset gtk2theme gtk3theme
@@ -1190,6 +1187,8 @@ getstyle () {
             gconf="gtk_theme"
             xfconf="ThemeName"
             kde="widgetStyle"
+            path="/proc/registry/HKEY_CURRENT_USER/Software/Microsoft"
+            path+="/Windows/CurrentVersion/Themes/CurrentTheme"
         ;;
 
         icons)
@@ -1209,127 +1208,139 @@ getstyle () {
         ;;
     esac
 
-    # Current DE
-    desktop="$XDG_CURRENT_DESKTOP"
-    desktop=${desktop,,}
-    desktop=${desktop^}
+    if [ -n "$DISPLAY" ]; then
+        # Current DE
+        desktop="$XDG_CURRENT_DESKTOP"
+        desktop=${desktop,,}
+        desktop=${desktop^}
 
-    case "$desktop" in
-        "KDE"*)
-            if type -p kde5-config >/dev/null 2>&1; then
-                kde_config_dir=$(kde5-config --localprefix)
+        case "$desktop" in
+            "KDE"*)
+                if type -p kde5-config >/dev/null 2>&1; then
+                    kde_config_dir=$(kde5-config --localprefix)
 
-            elif type -p kde4-config >/dev/null 2>&1; then
-                kde_config_dir=$(kde4-config --localprefix)
+                elif type -p kde4-config >/dev/null 2>&1; then
+                    kde_config_dir=$(kde4-config --localprefix)
 
-            elif type -p kde-config >/dev/null 2>&1; then
-                kde_config_dir=$(kde-config --localprefix)
-            fi
+                elif type -p kde-config >/dev/null 2>&1; then
+                    kde_config_dir=$(kde-config --localprefix)
+                fi
 
-            if [ -f "${kde_config_dir}/share/config/kdeglobals" ]; then
-                kde_config_file="${kde_config_dir}/share/config/kdeglobals"
+                if [ -f "${kde_config_dir}/share/config/kdeglobals" ]; then
+                    kde_config_file="${kde_config_dir}/share/config/kdeglobals"
 
-                theme=$(grep "^[^#]*$kde" "$kde_config_file")
-                theme=${theme/${kde}*=}
-                theme=${theme^}
+                    theme=$(grep "^[^#]*$kde" "$kde_config_file")
+                    theme=${theme/${kde}*=}
+                    theme=${theme^}
 
-                gtk_shorthand="on"
-                return
-            fi
-        ;;
+                    gtk_shorthand="on"
+                    return
+                fi
+            ;;
 
-        "Cinnamon")
-            if type -p gsettings >/dev/null 2>&1; then
-                gtk3theme=$(gsettings get org.cinnamon.desktop.interface $gsettings)
-                gtk3theme=${gtk3theme//"'"}
+            "Cinnamon")
+                if type -p gsettings >/dev/null 2>&1; then
+                    gtk3theme=$(gsettings get org.cinnamon.desktop.interface $gsettings)
+                    gtk3theme=${gtk3theme//"'"}
+                    gtk2theme=${gtk3theme}
+                fi
+            ;;
+
+            "Gnome"* | "Unity"* | "Budgie")
+                if type -p gsettings >/dev/null 2>&1; then
+                    gtk3theme=$(gsettings get org.gnome.desktop.interface $gsettings)
+                    gtk3theme=${gtk3theme//"'"}
+                    gtk2theme=${gtk3theme}
+
+                elif type -p gconftool-2 >/dev/null 2>&1; then
+                    gtk2theme=$(gconftool-2 -g /desktop/gnome/interface/$gconf)
+                fi
+            ;;
+
+            "Mate"*)
+                gtk3theme=$(gsettings get org.mate.interface $gsettings)
                 gtk2theme=${gtk3theme}
+            ;;
+
+            "Xfce"*)
+                if type -p xfconf-query >/dev/null 2>&1; then
+                    gtk2theme=$(xfconf-query -c xsettings -p /Net/$xfconf)
+                fi
+            ;;
+        esac
+
+        # Check for gtk2 theme
+        if [ -z "$gtk2theme" ]; then
+            if [ -f "$HOME/.gtkrc-2.0" ]; then
+                gtk2theme=$(grep "^[^#]*$name" "$HOME/.gtkrc-2.0")
+
+            elif [ -f "/etc/gtk-2.0/gtkrc" ]; then
+                gtk2theme=$(grep "^[^#]*$name" /etc/gtk-2.0/gtkrc)
             fi
-        ;;
 
-        "Gnome"* | "Unity"* | "Budgie")
-            if type -p gsettings >/dev/null 2>&1; then
-                gtk3theme=$(gsettings get org.gnome.desktop.interface $gsettings)
-                gtk3theme=${gtk3theme//"'"}
-                gtk2theme=${gtk3theme}
-
-            elif type -p gconftool-2 >/dev/null 2>&1; then
-                gtk2theme=$(gconftool-2 -g /desktop/gnome/interface/$gconf)
-            fi
-        ;;
-
-        "Mate"*)
-            gtk3theme=$(gsettings get org.mate.interface $gsettings)
-            gtk2theme=${gtk3theme}
-        ;;
-
-        "Xfce"*)
-            if type -p xfconf-query >/dev/null 2>&1; then
-                gtk2theme=$(xfconf-query -c xsettings -p /Net/$xfconf)
-            fi
-        ;;
-    esac
-
-    # Check for gtk2 theme
-    if [ -z "$gtk2theme" ]; then
-        if [ -f "$HOME/.gtkrc-2.0" ]; then
-            gtk2theme=$(grep "^[^#]*$name" "$HOME/.gtkrc-2.0")
-
-        elif [ -f "/etc/gtk-2.0/gtkrc" ]; then
-            gtk2theme=$(grep "^[^#]*$name" /etc/gtk-2.0/gtkrc)
+            gtk2theme=${gtk2theme/${name}*=}
+            gtk2theme=${gtk2theme//\"}
         fi
 
-        gtk2theme=${gtk2theme/${name}*=}
-        gtk2theme=${gtk2theme//\"}
-    fi
+        # Check for gtk3 theme
+        if [ -z "$gtk3theme" ]; then
+            if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
+                gtk3theme=$(grep "^[^#]*$name" "$HOME/.config/gtk-3.0/settings.ini")
 
-    # Check for gtk3 theme
-    if [ -z "$gtk3theme" ]; then
-        if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
-            gtk3theme=$(grep "^[^#]*$name" "$HOME/.config/gtk-3.0/settings.ini")
+            elif type -p gsettings >/dev/null 2>&1; then
+                gtk3theme="$(gsettings get org.gnome.desktop.interface $gsettings)"
+                gtk3theme=${gtk3theme//\'}
 
-        elif type -p gsettings >/dev/null 2>&1; then
-            gtk3theme="$(gsettings get org.gnome.desktop.interface $gsettings)"
-            gtk3theme=${gtk3theme//\'}
+            else
+                gtk3theme=$(grep "^[^#]*$name" /etc/gtk-3.0/settings.ini)
+            fi
 
+            gtk3theme=${gtk3theme/${name}*=}
+            gtk3theme=${gtk3theme//\"}
+            gtk3theme=${gtk3theme/[[:space:]]/ }
+        fi
+
+        # Toggle visibility of gtk themes.
+        [ "$gtk2" == "off" ] && unset gtk2theme
+        [ "$gtk3" == "off" ] && unset gtk3theme
+
+        # Format the string based on which themes exist
+        if  [ "$gtk2theme" ] && [ "$gtk2theme" == "$gtk3theme" ]; then
+            gtk3theme+=" [GTK2/3]"
+            unset gtk2theme
+
+        elif [ "$gtk2theme" ] && [ "$gtk3theme" ]; then
+            gtk2theme+=" [GTK2], "
+            gtk3theme+=" [GTK3] "
         else
-            gtk3theme=$(grep "^[^#]*$name" /etc/gtk-3.0/settings.ini)
+            [ "$gtk2theme" ] && gtk2theme+=" [GTK2] "
+            [ "$gtk3theme" ] && gtk3theme+=" [GTK3] "
         fi
 
-        gtk3theme=${gtk3theme/${name}*=}
-        gtk3theme=${gtk3theme//\"}
-        gtk3theme=${gtk3theme/[[:space:]]/ }
-    fi
+        # Final string
+        theme="${gtk2theme}${gtk3theme}"
+        theme=${theme//\"}
+        theme=${theme//\'}
 
-    # Toggle visibility of gtk themes.
-    [ "$gtk2" == "off" ] && unset gtk2theme
-    [ "$gtk3" == "off" ] && unset gtk3theme
+        # If the final string is empty print "None"
+        [ -z "$theme" ] && theme="None"
 
-    # Format the string based on which themes exist
-    if  [ "$gtk2theme" ] && [ "$gtk2theme" == "$gtk3theme" ]; then
-        gtk3theme+=" [GTK2/3]"
-        unset gtk2theme
-
-    elif [ "$gtk2theme" ] && [ "$gtk3theme" ]; then
-        gtk2theme+=" [GTK2], "
-        gtk3theme+=" [GTK3] "
+        # Make the output shorter by removing "[GTKX]" from the string
+        if [ "$gtk_shorthand" == "on" ]; then
+            theme=${theme/ '[GTK2]'}
+            theme=${theme/ '[GTK3]'}
+            theme=${theme/ '[GTK2/3]'}
+        fi
     else
-        [ "$gtk2theme" ] && gtk2theme+=" [GTK2] "
-        [ "$gtk3theme" ] && gtk3theme+=" [GTK3] "
-    fi
+        case "$os" in
+            "Windows")
+                theme="$(head -n1 $path 2>/dev/null)"
+                theme="${theme##*\\}"
+                theme="${theme%.*}"
+                theme="${theme^}"
+            ;;
 
-    # Final string
-    theme="${gtk2theme}${gtk3theme}"
-    theme=${theme//\"}
-    theme=${theme//\'}
-
-    # If the final string is empty print "None"
-    [ -z "$theme" ] && theme="None"
-
-    # Make the output shorter by removing "[GTKX]" from the string
-    if [ "$gtk_shorthand" == "on" ]; then
-        theme=${theme/ '[GTK2]'}
-        theme=${theme/ '[GTK3]'}
-        theme=${theme/ '[GTK2/3]'}
+        esac
     fi
 }
 
@@ -1561,27 +1572,6 @@ getcols () {
         # Clear formatting
         printf "%b%s" "$clear"
     fi
-}
-
-# }}}
-
-# Windows Visual Style {{{
-
-getvisualstyle () {
-    case "$os" in
-        "Windows"*)
-            path="/proc/registry/HKEY_CURRENT_USER/Software/Microsoft"
-            path+="/Windows/CurrentVersion/Themes/CurrentTheme"
-            visualstyle="$(head -n1 $path)"
-            visualstyle="${visualstyle##*\\}"
-            visualstyle="${visualstyle%.*}"
-            visualstyle="${visualstyle^}"
-        ;;
-
-        *)
-            visualstyle="This feature only works on Windows"
-        ;;
-    esac
 }
 
 # }}}

--- a/fetch
+++ b/fetch
@@ -1322,9 +1322,6 @@ getstyle () {
         theme=${theme//\"}
         theme=${theme//\'}
 
-        # If the final string is empty print "None"
-        [ -z "$theme" ] && theme="None"
-
         # Make the output shorter by removing "[GTKX]" from the string
         if [ "$gtk_shorthand" == "on" ]; then
             theme=${theme/ '[GTK2]'}


### PR DESCRIPTION
The Windows visual style is now a part of `getstyle`.

If `X` is running then the `DE` / `GTK Theme` is used, otherwise we use the Visual Style.