### PR TITLE
Cleanup 'stdout' functions

### DIFF
--- a/1.3.md
+++ b/1.3.md
@@ -16,3 +16,6 @@ is now calculated by fetch.
 
 **Song**<br \>
 - Added `song_shorthand` which prints the Artist/Title on seperate lines.
+
+**Theme**<br\>
+- Windows Visual Style is now a part of `getstyle`.

--- a/config/config
+++ b/config/config
@@ -348,19 +348,3 @@ config_file="$HOME/.config/fetch/config"
 
 
 # }}}
-
-# Other Options {{{
-
-# Separator to use in stdout mode.
-# --stdout_separator string
-stdout_separator="    "
-
-# Hide/Show the title in stdout mode.
-# --stdout_title on/off
-stdout_title="off"
-
-# Hide/Show each info's subtitle in stdout mode.
-# --stdout_subtitles on/off
-stdout_subtitles="on"
-
-# }}}

--- a/fetch
+++ b/fetch
@@ -2123,21 +2123,17 @@ prin () {
 # Stdout {{{
 
 stdout () {
-    printinfo () {
-        index=1
-        for func in "${args[@]}"; do
-
-            case "$func" in
-                "--stdout") continue ;;
-                "--"*) break ;;
-                *)
-                    case "${args[$((index + 1))]}" in "--"*) unset stdout_separator ;; esac
-                    info "$func"
-                ;;
-            esac
-            index=$((index + 1))
-        done
-    }
+    for func in "${args[@]}"; do
+        case "$func" in
+            "--"*) break ;;
+            *)
+                "get$func" 2>/dev/null
+                eval output="\$$func"
+                printf "$output "
+            ;;
+        esac
+    done
+    exit
 }
 
 # }}}
@@ -2492,12 +2488,13 @@ while [ "$1" ]; do
         --stdout_separator) stdout_separator="$2" ;;
         --stdout_subtitles) stdout_subtitles="$2" ;;
         --stdout)
+            stdout="on"
+            unset info_color colors
             case "$2" in
-                "--"* | "") stdout="on" ;;
-                *) stdout="on"; args=("$@"); stdout ;;
+                "--"* | "") ;;
+                *) shift; args=("$@"); stdout ;;
             esac
 
-            unset info_color colors
             underline="off"
             image="off"
             color_blocks="off"

--- a/fetch
+++ b/fetch
@@ -367,22 +367,6 @@ config_file="$HOME/.config/fetch/config"
 
 # }}}
 
-# Other Options {{{
-
-# Separator to use in stdout mode.
-# --stdout_separator string
-stdout_separator="    "
-
-# Hide/Show the title in stdout mode.
-# --stdout_title on/off
-stdout_title="off"
-
-# Hide/Show each info's subtitle in stdout mode.
-# --stdout_subtitles on/off
-stdout_subtitles="on"
-
-# }}}
-
 
 # }}}
 
@@ -2049,11 +2033,6 @@ info () {
             string="${bold}${title_color}${output}"
             string="${string/@/${at_color}@${title_color}}"
             length=${#output}
-
-            # Hide the title in stdout mode
-            [ "$stdout" == "on" ] && \
-            [ "$stdout_title" == "off" ] &&\
-                string=""
         ;;
 
         underline)
@@ -2071,22 +2050,7 @@ info () {
     [ -z "$2" ] && string=${string/*: }
 
     # Print the string
-    if [ "$stdout" == "on" ]; then
-
-        # Unset the vars containg escape codes as lemonbar doesn't
-        # support them.
-        unset -v bold subtitle_color clear colon_color info_color \
-        underline_color title_color at_color
-
-        # Show/Hide subtitles
-        [ "$stdout_subtitles" == "off" ] && string=${string/*: }
-
-        # If the string isn't empty, print it.
-        [ ! -z "$string" ] && printf "%s" "${string}${stdout_separator}"
-
-    else
-        printf "%b%s\n" "${padding}${string}${clear}"
-    fi
+    printf "%b%s\n" "${padding}${string}${clear}"
 }
 
 # }}}
@@ -2111,11 +2075,7 @@ prin () {
     esac
 
     # Print the info
-    if [ "$stdout" == "on" ]; then
-        printf "%s" "${string}${stdout_separator}"
-    else
-        printf "%b%s\n" "${padding}${string}${clear}"
-    fi
+    printf "%b%s\n" "${padding}${string}${clear}"
 }
 
 # }}}
@@ -2129,7 +2089,7 @@ stdout () {
             *)
                 "get$func" 2>/dev/null
                 eval output="\$$func"
-                printf "$output "
+                printf "$output  "
             ;;
         esac
     done
@@ -2359,9 +2319,6 @@ usage () { cat << EOF
     --stdout info info          Launch fetch in stdout mode which prints the info
                                 in a plain-text format that you can use with
                                 lemonbar etc.
-    --stdout_title on/off       Hide/Show the title in stdout mode.
-    --stdout_separator string   String to use as a separator in stdout mode.
-    --stdout_subtitles on/off   Hide/Show the subtitles in stdout mode.
 
 
     Screenshot:
@@ -2484,20 +2441,12 @@ while [ "$1" ]; do
         --scrot_cmd) scrot_cmd="$2" ;;
 
         # Stdout
-        --stdout_title) stdout_title="$2" ;;
-        --stdout_separator) stdout_separator="$2" ;;
-        --stdout_subtitles) stdout_subtitles="$2" ;;
         --stdout)
-            stdout="on"
             unset info_color colors
             case "$2" in
-                "--"* | "") ;;
+                "--"* | "") echo "--stdout requires at least one argument"; exit ;;
                 *) shift; args=("$@"); stdout ;;
             esac
-
-            underline="off"
-            image="off"
-            color_blocks="off"
         ;;
 
         # Other


### PR DESCRIPTION
This PR cleans up the `--stdout` functions and removes support for printing all
functions using `--stdout` without args as it was messy and slow.